### PR TITLE
画面の小さい端末で選択肢が途切れる問題 

### DIFF
--- a/lib/resources/pages/result_page.dart
+++ b/lib/resources/pages/result_page.dart
@@ -1,10 +1,7 @@
 import 'package:audioplayers/audioplayers.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_app/app/models/lesson.dart';
 import 'package:flutter_app/app/models/word.dart';
-import 'package:flutter_app/bootstrap/helpers.dart';
 import 'package:flutter_app/resources/widgets/safearea_widget.dart';
-import 'package:gap/gap.dart';
 import 'package:nylo_framework/nylo_framework.dart';
 
 class ResultPage extends NyStatefulWidget {

--- a/lib/resources/pages/word_page.dart
+++ b/lib/resources/pages/word_page.dart
@@ -77,7 +77,7 @@ class _WordPageState extends NyState<WordPage> {
       },
       child: Text(_words[_currentIndex].choices[choiceIndex].translation),
       style: OutlinedButton.styleFrom(
-        minimumSize: Size(double.infinity, 60),
+        minimumSize: Size(double.infinity, 58),
         side: BorderSide(color: ThemeColor.get(context).primaryAccent),
         foregroundColor: ThemeColor.get(context).buttonPrimaryContent,
       ),
@@ -131,11 +131,11 @@ class _WordPageState extends NyState<WordPage> {
           Expanded(
             flex: 6,
             child: Column(
-              mainAxisAlignment: MainAxisAlignment.center,
+              mainAxisAlignment: MainAxisAlignment.spaceEvenly,
               children: List.generate(
                 _words[_currentIndex].choices.length,
                 (index) => Padding(
-                  padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+                  padding: const EdgeInsets.symmetric(horizontal: 14),
                   child: _buildChoiceButton(index),
                 ),
               ),


### PR DESCRIPTION
closes #43 

- 修正前
<img width="308" alt="スクリーンショット 2024-05-01 0 46 58" src="https://github.com/laicosjp/hangul_app/assets/76689059/6fce65b7-7750-44c1-abab-ad88984006e1">


- 修正後
<img width="316" alt="スクリーンショット 2024-05-01 0 46 14" src="https://github.com/laicosjp/hangul_app/assets/76689059/8d1980eb-1470-47ac-8f38-fa0552c7760b">

画像はiPhoneSEのシュミレータ