### PR TITLE
ポリシーのURLを変更

### DIFF
--- a/lib/resources/pages/policy_page.dart
+++ b/lib/resources/pages/policy_page.dart
@@ -10,7 +10,7 @@ class PolicyPage extends NyStatefulWidget {
 }
 
 class _PolicyPageState extends NyState<PolicyPage> {
-  final url = "https://aldablitz-production.up.railway.app/policy";
+  final url = "https://hangul-app-astro.web.app/policy";
 
   @override
   Widget view(BuildContext context) {


### PR DESCRIPTION
blitz（railway）サーバーを節約のため停止するので、firebase hostingのurlに変更